### PR TITLE
Add REDIS_SENTINEL_PASSWORD

### DIFF
--- a/4.0/debian-9/rootfs/libredissentinel.sh
+++ b/4.0/debian-9/rootfs/libredissentinel.sh
@@ -76,6 +76,7 @@ export REDIS_MASTER_PORT_NUMBER="${REDIS_MASTER_PORT_NUMBER:-6379}"
 export REDIS_MASTER_SET="${REDIS_MASTER_SET:-mymaster}"
 export REDIS_SENTINEL_PORT_NUMBER="${REDIS_SENTINEL_PORT_NUMBER:-26379}"
 export REDIS_SENTINEL_QUORUM="${REDIS_SENTINEL_QUORUM:-2}"
+export REDIS_SENTINEL_PASSWORD="${REDIS_SENTINEL_PASSWORD:-}"
 EOF
     if [[ -f "${REDIS_MASTER_PASSWORD_FILE:-}" ]]; then
         cat <<"EOF"
@@ -151,6 +152,7 @@ redis_initialize() {
 
         # Service
         redis_conf_set "port" "$REDIS_SENTINEL_PORT_NUMBER"
+        [[ -z "$REDIS_SENTINEL_PASSWORD" ]] || redis_conf_set "requirepass" "$REDIS_SENTINEL_PASSWORD"
         redis_conf_set "bind" "0.0.0.0"
         redis_conf_set "daemonize" "yes"
         redis_conf_set "pidfile" "$REDIS_SENTINEL_PID_FILE"

--- a/4.0/ol-7/rootfs/libredissentinel.sh
+++ b/4.0/ol-7/rootfs/libredissentinel.sh
@@ -76,6 +76,7 @@ export REDIS_MASTER_PORT_NUMBER="${REDIS_MASTER_PORT_NUMBER:-6379}"
 export REDIS_MASTER_SET="${REDIS_MASTER_SET:-mymaster}"
 export REDIS_SENTINEL_PORT_NUMBER="${REDIS_SENTINEL_PORT_NUMBER:-26379}"
 export REDIS_SENTINEL_QUORUM="${REDIS_SENTINEL_QUORUM:-2}"
+export REDIS_SENTINEL_PASSWORD="${REDIS_SENTINEL_PASSWORD:-}"
 EOF
     if [[ -f "${REDIS_MASTER_PASSWORD_FILE:-}" ]]; then
         cat <<"EOF"
@@ -151,6 +152,7 @@ redis_initialize() {
 
         # Service
         redis_conf_set "port" "$REDIS_SENTINEL_PORT_NUMBER"
+        [[ -z "$REDIS_SENTINEL_PASSWORD" ]] || redis_conf_set "requirepass" "$REDIS_SENTINEL_PASSWORD"
         redis_conf_set "bind" "0.0.0.0"
         redis_conf_set "daemonize" "yes"
         redis_conf_set "pidfile" "$REDIS_SENTINEL_PID_FILE"

--- a/5.0/debian-9/rootfs/libredissentinel.sh
+++ b/5.0/debian-9/rootfs/libredissentinel.sh
@@ -76,6 +76,7 @@ export REDIS_MASTER_PORT_NUMBER="${REDIS_MASTER_PORT_NUMBER:-6379}"
 export REDIS_MASTER_SET="${REDIS_MASTER_SET:-mymaster}"
 export REDIS_SENTINEL_PORT_NUMBER="${REDIS_SENTINEL_PORT_NUMBER:-26379}"
 export REDIS_SENTINEL_QUORUM="${REDIS_SENTINEL_QUORUM:-2}"
+export REDIS_SENTINEL_PASSWORD="${REDIS_SENTINEL_PASSWORD:-}"
 EOF
     if [[ -f "${REDIS_MASTER_PASSWORD_FILE:-}" ]]; then
         cat <<"EOF"
@@ -151,6 +152,7 @@ redis_initialize() {
 
         # Service
         redis_conf_set "port" "$REDIS_SENTINEL_PORT_NUMBER"
+        [[ -z "$REDIS_SENTINEL_PASSWORD" ]] || redis_conf_set "requirepass" "$REDIS_SENTINEL_PASSWORD"
         redis_conf_set "bind" "0.0.0.0"
         redis_conf_set "daemonize" "yes"
         redis_conf_set "pidfile" "$REDIS_SENTINEL_PID_FILE"

--- a/5.0/ol-7/rootfs/libredissentinel.sh
+++ b/5.0/ol-7/rootfs/libredissentinel.sh
@@ -76,6 +76,7 @@ export REDIS_MASTER_PORT_NUMBER="${REDIS_MASTER_PORT_NUMBER:-6379}"
 export REDIS_MASTER_SET="${REDIS_MASTER_SET:-mymaster}"
 export REDIS_SENTINEL_PORT_NUMBER="${REDIS_SENTINEL_PORT_NUMBER:-26379}"
 export REDIS_SENTINEL_QUORUM="${REDIS_SENTINEL_QUORUM:-2}"
+export REDIS_SENTINEL_PASSWORD="${REDIS_SENTINEL_PASSWORD:-}"
 EOF
     if [[ -f "${REDIS_MASTER_PASSWORD_FILE:-}" ]]; then
         cat <<"EOF"
@@ -151,6 +152,7 @@ redis_initialize() {
 
         # Service
         redis_conf_set "port" "$REDIS_SENTINEL_PORT_NUMBER"
+        [[ -z "$REDIS_SENTINEL_PASSWORD" ]] || redis_conf_set "requirepass" "$REDIS_SENTINEL_PASSWORD"
         redis_conf_set "bind" "0.0.0.0"
         redis_conf_set "daemonize" "yes"
         redis_conf_set "pidfile" "$REDIS_SENTINEL_PID_FILE"

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ The Redis Sentinel instance can be customized by specifying environment variable
 - `REDIS_MASTER_PASSWORD`: Password to authenticate with the master. No defaults. As an alternative, you can mount a file with the password and set the `REDIS_MASTER_PASSWORD_FILE` variable.
 - `REDIS_SENTINEL_PORT_NUMBER`: Redis Sentinel port. Default: **26379**.
 - `REDIS_SENTINEL_QUORUM`: Number of Sentinels that need to agree about the fact the master is not reachable. Default: **2**.
+- `REDIS_SENTINEL_PASSWORD`: Password to authenticate with this sentinel and to authenticate to other sentinels. No defaults. Needs to be identical on all sentinels.
 
 ## Configuration file
 


### PR DESCRIPTION
**Description of the change**

Added REDIS_SENTINEL_PASSWORD to docs and libredissentinel.sh files

**Benefits**

It is now possible to secure redis sentinels created using this container.

**Possible drawbacks**

All sentinels need to have the same password.

p.s.: Thanks for this easy to use container! You are all doing great work!